### PR TITLE
Bump mirror-adapter from 0.0.4 to 0.0.5

### DIFF
--- a/.github/workflows/mirror.yaml
+++ b/.github/workflows/mirror.yaml
@@ -66,9 +66,9 @@ jobs:
           ls -Rhal official
           pwd
 
-          docker login docker.pkg.github.com/jenkins-zh/mirror-adapter/mirror-adapter:0.0.4 --username LinuxSuRen --password ${DOCKER_TOKEN}
+          docker login docker.pkg.github.com/jenkins-zh/mirror-adapter/mirror-adapter:0.0.5 --username LinuxSuRen --password ${DOCKER_TOKEN}
 
-          docker run -v $(pwd)/update-center-mirror-private/rootCA:/rootCA -v $(pwd)/official:/official -v $(pwd)/mirror:/mirror docker.pkg.github.com/jenkins-zh/mirror-adapter/mirror-adapter:0.0.4 -connection-check-url https://www.baidu.com/ \
+          docker run -v $(pwd)/update-center-mirror-private/rootCA:/rootCA -v $(pwd)/official:/official -v $(pwd)/mirror:/mirror docker.pkg.github.com/jenkins-zh/mirror-adapter/mirror-adapter:0.0.5 -connection-check-url https://www.baidu.com/ \
           -mirror-json /mirror/update-center.json -mirror-url https://mirrors.tuna.tsinghua.edu.cn/jenkins/ \
           -official-json /official/update-center.json \
           -key /rootCA/mirror-adapter.key \
@@ -76,7 +76,7 @@ jobs:
           -root-certificate /rootCA/mirror-adapter.crt \
           -mirror-provider tsinghua
 
-          docker run -v $(pwd)/update-center-mirror-private/rootCA:/rootCA -v $(pwd)/official:/official -v $(pwd)/mirror:/mirror docker.pkg.github.com/jenkins-zh/mirror-adapter/mirror-adapter:0.0.4 -connection-check-url https://www.baidu.com/ \
+          docker run -v $(pwd)/update-center-mirror-private/rootCA:/rootCA -v $(pwd)/official:/official -v $(pwd)/mirror:/mirror docker.pkg.github.com/jenkins-zh/mirror-adapter/mirror-adapter:0.0.5 -connection-check-url https://www.baidu.com/ \
           -mirror-json /mirror/current/updates/hudson.tools.JDKInstaller.json.html -tools -mirror-url https://mirrors.tuna.tsinghua.edu.cn/jenkins/ \
           -official-json /official/current/updates/hudson.tools.JDKInstaller.json.html \
           -key /rootCA/mirror-adapter.key \
@@ -84,7 +84,7 @@ jobs:
           -root-certificate /rootCA/mirror-adapter.crt \
           -mirror-provider tsinghua
 
-          docker run -v $(pwd)/update-center-mirror-private/rootCA:/rootCA -v $(pwd)/official:/official -v $(pwd)/mirror:/mirror docker.pkg.github.com/jenkins-zh/mirror-adapter/mirror-adapter:0.0.4 -connection-check-url https://www.baidu.com/ \
+          docker run -v $(pwd)/update-center-mirror-private/rootCA:/rootCA -v $(pwd)/official:/official -v $(pwd)/mirror:/mirror docker.pkg.github.com/jenkins-zh/mirror-adapter/mirror-adapter:0.0.5 -connection-check-url https://www.baidu.com/ \
           -mirror-json /mirror/current/updates/hudson.tasks.Maven.MavenInstaller.json.html -tools -mirror-url https://mirrors.tuna.tsinghua.edu.cn/jenkins/ \
           -official-json /official/current/updates/hudson.tasks.Maven.MavenInstaller.json.html \
           -key /rootCA/mirror-adapter.key \
@@ -92,7 +92,7 @@ jobs:
           -root-certificate /rootCA/mirror-adapter.crt \
           -mirror-provider tsinghua
 
-          docker run -v $(pwd)/update-center-mirror-private/rootCA:/rootCA -v $(pwd)/official:/official -v $(pwd)/mirror:/mirror docker.pkg.github.com/jenkins-zh/mirror-adapter/mirror-adapter:0.0.4 -connection-check-url https://www.baidu.com/ \
+          docker run -v $(pwd)/update-center-mirror-private/rootCA:/rootCA -v $(pwd)/official:/official -v $(pwd)/mirror:/mirror docker.pkg.github.com/jenkins-zh/mirror-adapter/mirror-adapter:0.0.5 -connection-check-url https://www.baidu.com/ \
           -mirror-json /mirror/current/update-center.json -mirror-url https://mirrors.tuna.tsinghua.edu.cn/jenkins/ \
           -official-json /official/current/update-center.json \
           -key /rootCA/mirror-adapter.key \
@@ -100,7 +100,7 @@ jobs:
           -root-certificate /rootCA/mirror-adapter.crt \
           -mirror-provider tsinghua
 
-          docker run -v $(pwd)/update-center-mirror-private/rootCA:/rootCA -v $(pwd)/official:/official -v $(pwd)/mirror:/mirror docker.pkg.github.com/jenkins-zh/mirror-adapter/mirror-adapter:0.0.4 -connection-check-url https://www.baidu.com/ \
+          docker run -v $(pwd)/update-center-mirror-private/rootCA:/rootCA -v $(pwd)/official:/official -v $(pwd)/mirror:/mirror docker.pkg.github.com/jenkins-zh/mirror-adapter/mirror-adapter:0.0.5 -connection-check-url https://www.baidu.com/ \
           -mirror-json /mirror/experimental/update-center.json -mirror-url https://mirrors.tuna.tsinghua.edu.cn/jenkins/ \
           -official-json /official/experimental/update-center.json \
           -key /rootCA/mirror-adapter.key \
@@ -108,7 +108,7 @@ jobs:
           -root-certificate /rootCA/mirror-adapter.crt \
           -mirror-provider tsinghua
 
-          docker run -v $(pwd)/update-center-mirror-private/rootCA:/rootCA -v $(pwd)/official:/official -v $(pwd)/mirror:/mirror docker.pkg.github.com/jenkins-zh/mirror-adapter/mirror-adapter:0.0.4 -connection-check-url https://www.baidu.com/ \
+          docker run -v $(pwd)/update-center-mirror-private/rootCA:/rootCA -v $(pwd)/official:/official -v $(pwd)/mirror:/mirror docker.pkg.github.com/jenkins-zh/mirror-adapter/mirror-adapter:0.0.5 -connection-check-url https://www.baidu.com/ \
           -mirror-json /mirror/stable-2.235/update-center.json -mirror-url https://mirrors.tuna.tsinghua.edu.cn/jenkins/ \
           -official-json /official/stable-2.235/update-center.json \
           -key /rootCA/mirror-adapter.key \
@@ -116,7 +116,7 @@ jobs:
           -root-certificate /rootCA/mirror-adapter.crt \
           -mirror-provider tsinghua
 
-          docker run -v $(pwd)/update-center-mirror-private/rootCA:/rootCA -v $(pwd)/official:/official -v $(pwd)/mirror:/mirror docker.pkg.github.com/jenkins-zh/mirror-adapter/mirror-adapter:0.0.4 -connection-check-url https://www.baidu.com/ \
+          docker run -v $(pwd)/update-center-mirror-private/rootCA:/rootCA -v $(pwd)/official:/official -v $(pwd)/mirror:/mirror docker.pkg.github.com/jenkins-zh/mirror-adapter/mirror-adapter:0.0.5 -connection-check-url https://www.baidu.com/ \
           -mirror-json /mirror/stable-2.222/update-center.json -mirror-url https://mirrors.tuna.tsinghua.edu.cn/jenkins/ \
           -official-json /official/stable-2.222/update-center.json \
           -key /rootCA/mirror-adapter.key \
@@ -124,7 +124,7 @@ jobs:
           -root-certificate /rootCA/mirror-adapter.crt \
           -mirror-provider tsinghua
 
-          docker run -v $(pwd)/update-center-mirror-private/rootCA:/rootCA -v $(pwd)/official:/official -v $(pwd)/mirror:/mirror docker.pkg.github.com/jenkins-zh/mirror-adapter/mirror-adapter:0.0.4 -connection-check-url https://www.baidu.com/ \
+          docker run -v $(pwd)/update-center-mirror-private/rootCA:/rootCA -v $(pwd)/official:/official -v $(pwd)/mirror:/mirror docker.pkg.github.com/jenkins-zh/mirror-adapter/mirror-adapter:0.0.5 -connection-check-url https://www.baidu.com/ \
           -mirror-json /mirror/stable-2.204/update-center.json -mirror-url https://mirrors.tuna.tsinghua.edu.cn/jenkins/ \
           -official-json /official/stable-2.204/update-center.json \
           -key /rootCA/mirror-adapter.key \
@@ -132,7 +132,7 @@ jobs:
           -root-certificate /rootCA/mirror-adapter.crt \
           -mirror-provider tsinghua
 
-          docker run -v $(pwd)/update-center-mirror-private/rootCA:/rootCA -v $(pwd)/official:/official -v $(pwd)/mirror:/mirror docker.pkg.github.com/jenkins-zh/mirror-adapter/mirror-adapter:0.0.4 -connection-check-url https://www.baidu.com/ \
+          docker run -v $(pwd)/update-center-mirror-private/rootCA:/rootCA -v $(pwd)/official:/official -v $(pwd)/mirror:/mirror docker.pkg.github.com/jenkins-zh/mirror-adapter/mirror-adapter:0.0.5 -connection-check-url https://www.baidu.com/ \
           -mirror-json /mirror/stable-2.190/update-center.json -mirror-url https://mirrors.tuna.tsinghua.edu.cn/jenkins/ \
           -official-json /official/stable-2.190/update-center.json \
           -key /rootCA/mirror-adapter.key \
@@ -140,7 +140,7 @@ jobs:
           -root-certificate /rootCA/mirror-adapter.crt \
           -mirror-provider tsinghua
 
-          docker run -v $(pwd)/update-center-mirror-private/rootCA:/rootCA -v $(pwd)/official:/official -v $(pwd)/mirror:/mirror docker.pkg.github.com/jenkins-zh/mirror-adapter/mirror-adapter:0.0.4 -connection-check-url https://www.baidu.com/ \
+          docker run -v $(pwd)/update-center-mirror-private/rootCA:/rootCA -v $(pwd)/official:/official -v $(pwd)/mirror:/mirror docker.pkg.github.com/jenkins-zh/mirror-adapter/mirror-adapter:0.0.5 -connection-check-url https://www.baidu.com/ \
           -mirror-json /mirror/stable-2.176/update-center.json -mirror-url https://mirrors.tuna.tsinghua.edu.cn/jenkins/ \
           -official-json /official/stable-2.176/update-center.json \
           -key /rootCA/mirror-adapter.key \
@@ -148,7 +148,7 @@ jobs:
           -root-certificate /rootCA/mirror-adapter.crt \
           -mirror-provider tsinghua
 
-          docker run -v $(pwd)/update-center-mirror-private/rootCA:/rootCA -v $(pwd)/official:/official -v $(pwd)/mirror:/mirror docker.pkg.github.com/jenkins-zh/mirror-adapter/mirror-adapter:0.0.4 -connection-check-url https://www.baidu.com/ \
+          docker run -v $(pwd)/update-center-mirror-private/rootCA:/rootCA -v $(pwd)/official:/official -v $(pwd)/mirror:/mirror docker.pkg.github.com/jenkins-zh/mirror-adapter/mirror-adapter:0.0.5 -connection-check-url https://www.baidu.com/ \
           -mirror-json /mirror/stable-2.164/update-center.json -mirror-url https://mirrors.tuna.tsinghua.edu.cn/jenkins/ \
           -official-json /official/stable-2.164/update-center.json \
           -key /rootCA/mirror-adapter.key \
@@ -156,7 +156,7 @@ jobs:
           -root-certificate /rootCA/mirror-adapter.crt \
           -mirror-provider tsinghua
 
-          docker run -v $(pwd)/update-center-mirror-private/rootCA:/rootCA -v $(pwd)/official:/official -v $(pwd)/mirror:/mirror docker.pkg.github.com/jenkins-zh/mirror-adapter/mirror-adapter:0.0.4 -connection-check-url https://www.baidu.com/ \
+          docker run -v $(pwd)/update-center-mirror-private/rootCA:/rootCA -v $(pwd)/official:/official -v $(pwd)/mirror:/mirror docker.pkg.github.com/jenkins-zh/mirror-adapter/mirror-adapter:0.0.5 -connection-check-url https://www.baidu.com/ \
           -mirror-json /mirror/stable-2.150/update-center.json -mirror-url https://mirrors.tuna.tsinghua.edu.cn/jenkins/ \
           -official-json /official/stable-2.150/update-center.json \
           -key /rootCA/mirror-adapter.key \
@@ -164,7 +164,7 @@ jobs:
           -root-certificate /rootCA/mirror-adapter.crt \
           -mirror-provider tsinghua
 
-          docker run -v $(pwd)/update-center-mirror-private/rootCA:/rootCA -v $(pwd)/official:/official -v $(pwd)/mirror:/mirror docker.pkg.github.com/jenkins-zh/mirror-adapter/mirror-adapter:0.0.4 -connection-check-url https://www.baidu.com/ \
+          docker run -v $(pwd)/update-center-mirror-private/rootCA:/rootCA -v $(pwd)/official:/official -v $(pwd)/mirror:/mirror docker.pkg.github.com/jenkins-zh/mirror-adapter/mirror-adapter:0.0.5 -connection-check-url https://www.baidu.com/ \
           -mirror-json /mirror/stable-2.138/update-center.json -mirror-url https://mirrors.tuna.tsinghua.edu.cn/jenkins/ \
           -official-json /official/stable-2.138/update-center.json \
           -key /rootCA/mirror-adapter.key \
@@ -172,7 +172,7 @@ jobs:
           -root-certificate /rootCA/mirror-adapter.crt \
           -mirror-provider tsinghua
 
-          docker run -v $(pwd)/update-center-mirror-private/rootCA:/rootCA -v $(pwd)/official:/official -v $(pwd)/mirror:/mirror docker.pkg.github.com/jenkins-zh/mirror-adapter/mirror-adapter:0.0.4 -connection-check-url https://www.baidu.com/ \
+          docker run -v $(pwd)/update-center-mirror-private/rootCA:/rootCA -v $(pwd)/official:/official -v $(pwd)/mirror:/mirror docker.pkg.github.com/jenkins-zh/mirror-adapter/mirror-adapter:0.0.5 -connection-check-url https://www.baidu.com/ \
           -mirror-json /mirror/stable-2.121/update-center.json -mirror-url https://mirrors.tuna.tsinghua.edu.cn/jenkins/ \
           -official-json /official/stable-2.121/update-center.json \
           -key /rootCA/mirror-adapter.key \
@@ -180,7 +180,7 @@ jobs:
           -root-certificate /rootCA/mirror-adapter.crt \
           -mirror-provider tsinghua
 
-          docker run -v $(pwd)/update-center-mirror-private/rootCA:/rootCA -v $(pwd)/official:/official -v $(pwd)/mirror:/mirror docker.pkg.github.com/jenkins-zh/mirror-adapter/mirror-adapter:0.0.4 -connection-check-url https://www.baidu.com/ \
+          docker run -v $(pwd)/update-center-mirror-private/rootCA:/rootCA -v $(pwd)/official:/official -v $(pwd)/mirror:/mirror docker.pkg.github.com/jenkins-zh/mirror-adapter/mirror-adapter:0.0.5 -connection-check-url https://www.baidu.com/ \
           -mirror-json /mirror/stable-2.107/update-center.json -mirror-url https://mirrors.tuna.tsinghua.edu.cn/jenkins/ \
           -official-json /official/stable-2.107/update-center.json \
           -key /rootCA/mirror-adapter.key \
@@ -188,7 +188,7 @@ jobs:
           -root-certificate /rootCA/mirror-adapter.crt \
           -mirror-provider tsinghua
 
-          docker run -v $(pwd)/update-center-mirror-private/rootCA:/rootCA -v $(pwd)/official:/official -v $(pwd)/mirror:/mirror docker.pkg.github.com/jenkins-zh/mirror-adapter/mirror-adapter:0.0.4 -connection-check-url https://www.baidu.com/ \
+          docker run -v $(pwd)/update-center-mirror-private/rootCA:/rootCA -v $(pwd)/official:/official -v $(pwd)/mirror:/mirror docker.pkg.github.com/jenkins-zh/mirror-adapter/mirror-adapter:0.0.5 -connection-check-url https://www.baidu.com/ \
           -mirror-json /mirror/stable-1.651/update-center.json -mirror-url https://mirrors.tuna.tsinghua.edu.cn/jenkins/ \
           -official-json /official/stable-1.651/update-center.json \
           -key /rootCA/mirror-adapter.key \
@@ -196,7 +196,7 @@ jobs:
           -root-certificate /rootCA/mirror-adapter.crt \
           -mirror-provider tsinghua
 
-          docker run -v $(pwd)/update-center-mirror-private/rootCA:/rootCA -v $(pwd)/official:/official -v $(pwd)/mirror:/mirror docker.pkg.github.com/jenkins-zh/mirror-adapter/mirror-adapter:0.0.4 -connection-check-url https://www.baidu.com/ \
+          docker run -v $(pwd)/update-center-mirror-private/rootCA:/rootCA -v $(pwd)/official:/official -v $(pwd)/mirror:/mirror docker.pkg.github.com/jenkins-zh/mirror-adapter/mirror-adapter:0.0.5 -connection-check-url https://www.baidu.com/ \
           -mirror-json /mirror/dynamic-stable-2.222.4/update-center.json -mirror-url https://mirrors.tuna.tsinghua.edu.cn/jenkins/ \
           -official-json /official/dynamic-stable-2.222.4/update-center.json \
           -key /rootCA/mirror-adapter.key \
@@ -204,7 +204,7 @@ jobs:
           -root-certificate /rootCA/mirror-adapter.crt \
           -mirror-provider tsinghua
 
-          docker run -v $(pwd)/update-center-mirror-private/rootCA:/rootCA -v $(pwd)/official:/official -v $(pwd)/mirror:/mirror docker.pkg.github.com/jenkins-zh/mirror-adapter/mirror-adapter:0.0.4 -connection-check-url https://www.baidu.com/ \
+          docker run -v $(pwd)/update-center-mirror-private/rootCA:/rootCA -v $(pwd)/official:/official -v $(pwd)/mirror:/mirror docker.pkg.github.com/jenkins-zh/mirror-adapter/mirror-adapter:0.0.5 -connection-check-url https://www.baidu.com/ \
           -mirror-json /mirror/dynamic-stable-2.235.2/update-center.json -mirror-url https://mirrors.tuna.tsinghua.edu.cn/jenkins/ \
           -official-json /official/dynamic-stable-2.235.2/update-center.json \
           -key /rootCA/mirror-adapter.key \
@@ -212,7 +212,7 @@ jobs:
           -root-certificate /rootCA/mirror-adapter.crt \
           -mirror-provider tsinghua
 
-          docker run -v $(pwd)/update-center-mirror-private/rootCA:/rootCA -v $(pwd)/official:/official -v $(pwd)/mirror:/mirror docker.pkg.github.com/jenkins-zh/mirror-adapter/mirror-adapter:0.0.4 -connection-check-url https://www.baidu.com/ \
+          docker run -v $(pwd)/update-center-mirror-private/rootCA:/rootCA -v $(pwd)/official:/official -v $(pwd)/mirror:/mirror docker.pkg.github.com/jenkins-zh/mirror-adapter/mirror-adapter:0.0.5 -connection-check-url https://www.baidu.com/ \
           -mirror-json /mirror/2.150/update-center.json -mirror-url https://mirrors.tuna.tsinghua.edu.cn/jenkins/ \
           -official-json /official/2.150/update-center.json \
           -key /rootCA/mirror-adapter.key \
@@ -220,7 +220,7 @@ jobs:
           -root-certificate /rootCA/mirror-adapter.crt \
           -mirror-provider tsinghua
 
-          docker run -v $(pwd)/update-center-mirror-private/rootCA:/rootCA -v $(pwd)/official:/official -v $(pwd)/mirror:/mirror docker.pkg.github.com/jenkins-zh/mirror-adapter/mirror-adapter:0.0.4 -connection-check-url https://www.baidu.com/ \
+          docker run -v $(pwd)/update-center-mirror-private/rootCA:/rootCA -v $(pwd)/official:/official -v $(pwd)/mirror:/mirror docker.pkg.github.com/jenkins-zh/mirror-adapter/mirror-adapter:0.0.5 -connection-check-url https://www.baidu.com/ \
           -mirror-json /mirror/2.164/update-center.json -mirror-url https://mirrors.tuna.tsinghua.edu.cn/jenkins/ \
           -official-json /official/2.164/update-center.json \
           -key /rootCA/mirror-adapter.key \
@@ -228,7 +228,7 @@ jobs:
           -root-certificate /rootCA/mirror-adapter.crt \
           -mirror-provider tsinghua
 
-          docker run -v $(pwd)/update-center-mirror-private/rootCA:/rootCA -v $(pwd)/official:/official -v $(pwd)/mirror:/mirror docker.pkg.github.com/jenkins-zh/mirror-adapter/mirror-adapter:0.0.4 -connection-check-url https://www.baidu.com/ \
+          docker run -v $(pwd)/update-center-mirror-private/rootCA:/rootCA -v $(pwd)/official:/official -v $(pwd)/mirror:/mirror docker.pkg.github.com/jenkins-zh/mirror-adapter/mirror-adapter:0.0.5 -connection-check-url https://www.baidu.com/ \
           -mirror-json /mirror/2.176/update-center.json -mirror-url https://mirrors.tuna.tsinghua.edu.cn/jenkins/ \
           -official-json /official/2.176/update-center.json \
           -key /rootCA/mirror-adapter.key \
@@ -236,7 +236,7 @@ jobs:
           -root-certificate /rootCA/mirror-adapter.crt \
           -mirror-provider tsinghua
 
-          docker run -v $(pwd)/update-center-mirror-private/rootCA:/rootCA -v $(pwd)/official:/official -v $(pwd)/mirror:/mirror docker.pkg.github.com/jenkins-zh/mirror-adapter/mirror-adapter:0.0.4 -connection-check-url https://www.baidu.com/ \
+          docker run -v $(pwd)/update-center-mirror-private/rootCA:/rootCA -v $(pwd)/official:/official -v $(pwd)/mirror:/mirror docker.pkg.github.com/jenkins-zh/mirror-adapter/mirror-adapter:0.0.5 -connection-check-url https://www.baidu.com/ \
           -mirror-json /mirror/2.190/update-center.json -mirror-url https://mirrors.tuna.tsinghua.edu.cn/jenkins/ \
           -official-json /official/2.190/update-center.json \
           -key /rootCA/mirror-adapter.key \
@@ -244,7 +244,7 @@ jobs:
           -root-certificate /rootCA/mirror-adapter.crt \
           -mirror-provider tsinghua
 
-          docker run -v $(pwd)/update-center-mirror-private/rootCA:/rootCA -v $(pwd)/official:/official -v $(pwd)/mirror:/mirror docker.pkg.github.com/jenkins-zh/mirror-adapter/mirror-adapter:0.0.4 -connection-check-url https://www.baidu.com/ \
+          docker run -v $(pwd)/update-center-mirror-private/rootCA:/rootCA -v $(pwd)/official:/official -v $(pwd)/mirror:/mirror docker.pkg.github.com/jenkins-zh/mirror-adapter/mirror-adapter:0.0.5 -connection-check-url https://www.baidu.com/ \
           -mirror-json /mirror/2.204/update-center.json -mirror-url https://mirrors.tuna.tsinghua.edu.cn/jenkins/ \
           -official-json /official/2.204/update-center.json \
           -key /rootCA/mirror-adapter.key \
@@ -252,7 +252,7 @@ jobs:
           -root-certificate /rootCA/mirror-adapter.crt \
           -mirror-provider tsinghua
 
-          docker run -v $(pwd)/update-center-mirror-private/rootCA:/rootCA -v $(pwd)/official:/official -v $(pwd)/mirror:/mirror docker.pkg.github.com/jenkins-zh/mirror-adapter/mirror-adapter:0.0.4 -connection-check-url https://www.baidu.com/ \
+          docker run -v $(pwd)/update-center-mirror-private/rootCA:/rootCA -v $(pwd)/official:/official -v $(pwd)/mirror:/mirror docker.pkg.github.com/jenkins-zh/mirror-adapter/mirror-adapter:0.0.5 -connection-check-url https://www.baidu.com/ \
           -mirror-json /mirror/2.222/update-center.json -mirror-url https://mirrors.tuna.tsinghua.edu.cn/jenkins/ \
           -official-json /official/2.222/update-center.json \
           -key /rootCA/mirror-adapter.key \
@@ -260,7 +260,7 @@ jobs:
           -root-certificate /rootCA/mirror-adapter.crt \
           -mirror-provider tsinghua
 
-          docker run -v $(pwd)/update-center-mirror-private/rootCA:/rootCA -v $(pwd)/official:/official -v $(pwd)/mirror:/mirror docker.pkg.github.com/jenkins-zh/mirror-adapter/mirror-adapter:0.0.4 -connection-check-url https://www.baidu.com/ \
+          docker run -v $(pwd)/update-center-mirror-private/rootCA:/rootCA -v $(pwd)/official:/official -v $(pwd)/mirror:/mirror docker.pkg.github.com/jenkins-zh/mirror-adapter/mirror-adapter:0.0.5 -connection-check-url https://www.baidu.com/ \
           -mirror-json /mirror/2.235/update-center.json -mirror-url https://mirrors.tuna.tsinghua.edu.cn/jenkins/ \
           -official-json /official/2.235/update-center.json \
           -key /rootCA/mirror-adapter.key \


### PR DESCRIPTION
Thanks to @yJunS for fixing a problem. The PR address is https://github.com/jenkins-zh/mirror-adapter/pull/11.