### PR TITLE
Delete a not exists version which is 2.235.4

### DIFF
--- a/.github/workflows/mirror.yaml
+++ b/.github/workflows/mirror.yaml
@@ -55,7 +55,6 @@ jobs:
           curl https://mirrors.tuna.tsinghua.edu.cn/jenkins/updates/stable-1.651/update-center.json -o official/stable-1.651/update-center.json --create-dirs
           curl https://mirrors.tuna.tsinghua.edu.cn/jenkins/updates/dynamic-stable-2.222.4/update-center.json -o official/dynamic-stable-2.222.4/update-center.json --create-dirs
           curl https://mirrors.tuna.tsinghua.edu.cn/jenkins/updates/dynamic-stable-2.235.5/update-center.json -o official/dynamic-stable-2.235.5/update-center.json --create-dirs
-          curl https://mirrors.tuna.tsinghua.edu.cn/jenkins/updates/dynamic-stable-2.235.4/update-center.json -o official/dynamic-stable-2.235.4/update-center.json --create-dirs
           curl https://mirrors.tuna.tsinghua.edu.cn/jenkins/updates/dynamic-stable-2.235.3/update-center.json -o official/dynamic-stable-2.235.3/update-center.json --create-dirs
           curl https://mirrors.tuna.tsinghua.edu.cn/jenkins/updates/dynamic-stable-2.235.2/update-center.json -o official/dynamic-stable-2.235.2/update-center.json --create-dirs
           curl https://mirrors.tuna.tsinghua.edu.cn/jenkins/updates/dynamic-stable-2.235.1/update-center.json -o official/dynamic-stable-2.235.1/update-center.json --create-dirs
@@ -222,14 +221,6 @@ jobs:
           docker run -v $(pwd)/update-center-mirror-private/rootCA:/rootCA -v $(pwd)/official:/official -v $(pwd)/mirror:/mirror docker.pkg.github.com/jenkins-zh/mirror-adapter/mirror-adapter:0.0.6 -connection-check-url https://www.baidu.com/ \
           -mirror-json /mirror/dynamic-stable-2.235.5/update-center.json -mirror-url https://mirrors.tuna.tsinghua.edu.cn/jenkins/ \
           -official-json /official/dynamic-stable-2.235.5/update-center.json \
-          -key /rootCA/mirror-adapter.key \
-          -certificate /rootCA/mirror-adapter.crt \
-          -root-certificate /rootCA/mirror-adapter.crt \
-          -mirror-provider tsinghua
-
-          docker run -v $(pwd)/update-center-mirror-private/rootCA:/rootCA -v $(pwd)/official:/official -v $(pwd)/mirror:/mirror docker.pkg.github.com/jenkins-zh/mirror-adapter/mirror-adapter:0.0.6 -connection-check-url https://www.baidu.com/ \
-          -mirror-json /mirror/dynamic-stable-2.235.4/update-center.json -mirror-url https://mirrors.tuna.tsinghua.edu.cn/jenkins/ \
-          -official-json /official/dynamic-stable-2.235.4/update-center.json \
           -key /rootCA/mirror-adapter.key \
           -certificate /rootCA/mirror-adapter.crt \
           -root-certificate /rootCA/mirror-adapter.crt \


### PR DESCRIPTION
A missing version will cause an exception. This error was brought from https://github.com/jenkins-zh/update-center-mirror/pull/20